### PR TITLE
Use ansi2html instead of aha

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y aha
+          sudo pip install ansi2html
           curl -fLOsS https://github.com/nineinchnick/trino-git/releases/download/v$TRINO_GIT_VERSION/trino-git-$TRINO_GIT_VERSION.zip
           unzip trino-git-$TRINO_GIT_VERSION.zip
       - name: Start Trino

--- a/bin/reports.sh
+++ b/bin/reports.sh
@@ -34,14 +34,12 @@ queries=("$@")
 
 function run_query() {
     local file=$1
-    local SED_PR_LINK_UNESCAPE_PATTERN='s!&lt;a href=&quot;https://github.com/trinodb/trino/pull/([0-9]+)&quot;&gt;link&lt;/a&gt;!<a href="https://github.com/trinodb/trino/pull/\1">link</a>!'
     echo >&2 "Executing query from $file"
     docker exec \
         $container_name \
         trino --catalog hive --schema v2 \
         -f "/tmp/$(basename "$file")" \
-        --output-format=ALIGNED | aha -n |
-        sed -E "${SED_PR_LINK_UNESCAPE_PATTERN}" # Unescape PR links which were escaped by aha
+        --output-format=ALIGNED | ansi2html --inline --unescape
 }
 
 GITHUB_SERVER_URL=${GITHUB_SERVER_URL:-https://github.com}


### PR DESCRIPTION
ansi2html can be told not to escape HTML tags in it's input.
This saves us from the woes of using sed for unescaping it later.