### PR TITLE
Break down authors per month chart to per org

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -21,7 +21,7 @@ jobs:
       TRINO_SRC_SCHEMA: github.default
       EMPTY_INSERT_LIMIT: 5
       # sync for reviews takes too long, sync for review_comments is broken because Github return a Server Error
-      SYNC_TABLES: runs,jobs,steps,check_suites,check_runs,check_run_annotations,pulls,issues,issue_comments,artifacts
+      SYNC_TABLES: runs,jobs,steps,check_suites,check_runs,check_run_annotations,pulls,issues,issue_comments,commits,artifacts
     steps:
       - uses: actions/checkout@v2
       - name: Download trino-rest

--- a/sql/pr/authors-per-month.sql
+++ b/sql/pr/authors-per-month.sql
@@ -1,76 +1,71 @@
 -- Authors per month
-WITH authors AS (
+-- note that org membership is current, so if someone joins an org, all their historical commits shift toward this org
+WITH
+authors AS (
     SELECT
       date_trunc('month', date(c.commit_time AT TIME ZONE 'UTC')) AS month
-    , count(distinct ai.name) AS count
+    , coalesce(m.org, '') AS org
     , array_agg(distinct ai.name order by ai.name) AS names
     FROM git.default.commits c
     JOIN memory.default.idents ai ON ai.name = c.author_name OR CONTAINS(ai.extra_names, c.author_name)
-    GROUP BY 1
-),
-accumulated AS (
+    LEFT JOIN members m ON CONTAINS(ai.logins, m.login)
+    GROUP BY 1, 2
+)
+, accumulated AS (
     SELECT
       a.*
-    , array_sort(array_distinct(flatten(array_agg(a.names) OVER (ORDER BY a.month)))) AS all_names
+    , array_sort(array_distinct(flatten(array_agg(a.names) OVER (PARTITION BY a.org ORDER BY a.month)))) AS all_names
     FROM authors a
     GROUP BY 1, 2, 3
-),
-new AS (
+)
+, new AS (
     SELECT
       a.month
-    , a.count
+    , a.org
+    , a.names
+    , cardinality(a.names) AS num_names
     , a.all_names
-    , cardinality(a.all_names) AS total_count
-    , array_except(a.names, lag(a.all_names, 1, array[]) OVER (ORDER BY a.month)) AS new_names
+    , cardinality(a.all_names) AS num_all_names
+    , array_except(a.names, lag(a.all_names, 1, array[]) OVER (PARTITION BY a.org ORDER BY a.month)) AS new_names
     FROM accumulated a
 )
-SELECT
-  a.month AS "Month"
-, bar(a.count / CAST(max(a.count) OVER () AS double), 20, rgb(0, 155, 0), rgb(0, 155, 0)) AS "Authors count chart"
-, bar(cardinality(a.new_names) / CAST(max(cardinality(a.new_names)) OVER () AS double), 20, rgb(0, 155, 0), rgb(0, 155, 0)) AS "New authors count chart"
-, bar(cardinality(a.all_names) / CAST(max(cardinality(a.all_names)) OVER () AS double), 20, rgb(0, 155, 0), rgb(0, 155, 0)) AS "All authors count chart"
-, a.count AS "Authors count"
-, cardinality(a.new_names) AS "New authors count"
-, cardinality(a.all_names) AS "All authors count"
---, cardinality(lag(a.all_names) OVER (ORDER BY a.month)) as all_prev_count
-, new_names AS "New authors"
-FROM new a
-ORDER BY 1 DESC
-LIMIT 24;
-
-/* same but with emails
-WITH authors AS (
-    SELECT
-      date_trunc('month', date(c.commit_time AT TIME ZONE 'UTC')) AS month
-    , count(distinct ai.email) AS count
-    , array_agg(distinct ai.email) AS emails
-    FROM git.default.commits c
-    JOIN memory.default.idents ai ON ai.email = c.author_email OR CONTAINS(ai.extra_emails, c.author_email)
-    GROUP BY 1
-),
-accumulated AS (
-    SELECT
-      a.*
-    , array_distinct(flatten(array_agg(a.emails) OVER (ORDER BY a.month))) AS all_emails
-    FROM authors a
-    GROUP BY 1, 2, 3
-),
-new AS (
+, grouped AS (
     SELECT
       a.month
-    , a.count
-    , cardinality(a.all_emails) AS total_count
-    , array_except(a.emails, lag(a.all_emails) OVER (ORDER BY a.month)) AS new_emails
-    FROM accumulated a
+    -- group into tuples with size as first item to be able to sort descending by size
+    , reverse(array_sort(array_agg((a.num_names, a.names)))) AS names
+    , reverse(array_sort(array_agg((a.num_all_names, a.all_names)))) AS all_names
+    , sum(a.num_names) AS num_names
+    , sum(a.num_all_names) AS num_all_names
+    , cast(max(sum(a.num_names)) OVER () AS double) AS max_num_names
+    , cast(max(sum(a.num_all_names)) OVER () AS double) AS max_num_all_names
+    , flatten(array_agg(new_names)) AS new_names
+    FROM new a
+    GROUP BY 1
 )
 SELECT
   a.month AS "Month"
-, bar(a.count / CAST(max(a.count) OVER () AS double), 20, rgb(0, 155, 0), rgb(255, 0, 0)) AS "Authors count chart"
-, bar(cardinality(a.new_emails) / CAST(max(cardinality(a.new_emails)) OVER () AS double), 20, rgb(0, 155, 0), rgb(255, 0, 0)) AS "New authors count chart"
-, a.count AS "Authors count"
-, cardinality(a.new_emails) AS "New authors count"
-, new_emails AS "New authors"
-FROM new a
+-- create a bar chart for every org and join all charts
+, array_join(transform(
+    -- replace size with group index and names with cardinality
+    zip(
+        transform(sequence(1, cardinality(a.names)), x -> (x - 1) / cast(cardinality(a.names) as double)),
+        transform(a.names, x -> cardinality(x[2]))
+    ),
+    x -> rtrim(bar(x[2] / a.max_num_names, 20, color(x[1], rgb(255, 0, 0), rgb(0, 0, 255)), color(x[1], rgb(255, 0, 0), rgb(0, 0, 255))))
+  ), '') AS "Authors per org chart"
+, bar(cardinality(a.new_names) / CAST(max(cardinality(a.new_names)) OVER () AS double), 20, rgb(0, 155, 0), rgb(0, 155, 0)) AS "New authors count chart"
+, array_join(transform(
+    zip(
+        transform(sequence(1, cardinality(a.all_names)), x -> (x - 1) / cast(cardinality(a.all_names) as double)),
+        transform(a.all_names, x -> cardinality(x[2]))
+    ),
+    x -> rtrim(bar(x[2] / a.max_num_all_names, 20, color(x[1], rgb(255, 0, 0), rgb(0, 0, 255)), color(x[1], rgb(255, 0, 0), rgb(0, 0, 255))))
+  ), '') AS "All authors per org chart"
+, a.num_names AS "Authors count"
+, cardinality(a.new_names) AS "New authors count"
+, a.num_all_names AS "All authors count"
+, new_names AS "New authors"
+FROM grouped a
 ORDER BY 1 DESC
 LIMIT 24;
-*/

--- a/sql/pr/top-authors.sql
+++ b/sql/pr/top-authors.sql
@@ -1,24 +1,32 @@
 -- Top 10 authors per year
+-- note that org membership is current, so if someone joins an org, all their historical commits shift toward this org
 WITH mergers_per_year AS (
     SELECT
         year(c.commit_time AT TIME ZONE 'UTC') AS year,
-        ai.name || ' <' || regexp_replace(ai.email, '(?<=.)[^@](?=[^@]*?@)|(?:(?<=@.)|(?!^)\G(?=[^@]*$)).(?=.*\.)', '*') || '>' AS identifier,
+        ai.name,
+        regexp_replace(ai.email, '(?<=.)[^@](?=[^@]*?@)|(?:(?<=@.)|(?!^)\G(?=[^@]*$)).(?=.*\.)', '*') AS email,
+        m.org,
         count(*) AS commits_count
     FROM git.default.commits c
     JOIN memory.default.idents ai ON ai.email = c.author_email OR CONTAINS(ai.extra_emails, c.author_email)
-    GROUP BY 1, 2
+    LEFT JOIN members m ON CONTAINS(ai.logins, m.login)
+    GROUP BY 1, 2, 3, 4
 ),
 ranked_per_year AS (
     SELECT
         year,
-        identifier,
+        name,
+        email,
+        org,
         commits_count,
         row_number() OVER (PARTITION BY year ORDER BY commits_count DESC) AS in_year_rank
     FROM mergers_per_year
 )
 SELECT
     year,
-    identifier,
+    name,
+    email,
+    org,
     commits_count
 FROM ranked_per_year
 WHERE in_year_rank < 11

--- a/sql/pr/top-mergers.sql
+++ b/sql/pr/top-mergers.sql
@@ -2,25 +2,32 @@
 WITH mergers_per_year AS (
     SELECT
         year(c.commit_time AT TIME ZONE 'UTC') AS year,
-        ci.name || ' <' || regexp_replace(ci.email, '(?<=.)[^@](?=[^@]*?@)|(?:(?<=@.)|(?!^)\G(?=[^@]*$)).(?=.*\.)', '*') || '>' AS identifier,
+        ci.name,
+        regexp_replace(ci.email, '(?<=.)[^@](?=[^@]*?@)|(?:(?<=@.)|(?!^)\G(?=[^@]*$)).(?=.*\.)', '*') AS email,
+        m.org,
         count(*) AS commits_count
     FROM git.default.commits c
     JOIN memory.default.idents ai ON ai.email = c.author_email OR CONTAINS(ai.extra_emails, c.author_email)
     JOIN memory.default.idents ci ON ci.email = c.committer_email OR CONTAINS(ci.extra_emails, c.committer_email)
+    LEFT JOIN members m ON CONTAINS(ci.logins, m.login)
     WHERE ai.email != ci.email
-    GROUP BY 1, 2
+    GROUP BY 1, 2, 3, 4
 ),
 ranked_per_year AS (
     SELECT
         year,
-        identifier,
+        name,
+        email,
+        org,
         commits_count,
         row_number() OVER (PARTITION BY year ORDER BY commits_count DESC) AS in_year_rank
     FROM mergers_per_year
 )
 SELECT
     year,
-    identifier,
+    name,
+    email,
+    org,
     commits_count
 FROM ranked_per_year
 WHERE in_year_rank < 11


### PR DESCRIPTION
This is the first example of drawing stacked charts.

It supports tracking multiple orgs, not just Starburst, but the `members` table is only populated manually for the `starburst` org. It also doesn't represent membership over time, so when someone joins a new org (starburst...) all their historical commits will count toward this org.

Membership for commit authors is tracked using:
* when building the idents table, git commits are joined to GitHub commits that also include GitHub users for author and committer, so all possible logins for an ident are attached
* GitHub commits are updated on a regular basis; git commits are fetched by cloning the repo on every run
* org membership has been fetched once, manually, for a single org, and is _not_ tracked over time