### PR TITLE
Detect Sith lord pairs

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Execute queries
         run: |
           ./bin/reports.sh reports/ci-cd/index.md "Trino CI/CD Reports" sql/ci-cd/{health,runs-queue-time-per-day,runs-duration-per-day,runs-job-cumulative-duration-per-day,concurrent-jobs-per-day,jobs-duration,flaky-tests}.sql
-          ./bin/reports.sh reports/pr/index.md "Trino PR Reports" sql/pr/{idents,burndown,authors-per-month,changes-per-month,prs-per-author,top-reviewers,top-authors,top-mergers,avg-time-to-merge,avg-time-to-merge-since-creation,avg-time-to-first-review,stale-prs,awaiting-review}.sql
+          ./bin/reports.sh reports/pr/index.md "Trino PR Reports" sql/pr/{idents,burndown,authors-per-month,changes-per-month,prs-per-author,top-reviewers,top-authors,top-mergers,sith-lords,avg-time-to-merge,avg-time-to-merge-since-creation,avg-time-to-first-review,stale-prs,awaiting-review}.sql
       - name: Commit report
         run: |
           git config --global user.name 'Jan Was'

--- a/sql/pr/sith-lords.sql
+++ b/sql/pr/sith-lords.sql
@@ -1,0 +1,29 @@
+-- Always two, there are. No more. No less. A master and an apprentice
+WITH pairs AS (
+    SELECT
+        c.commit_time AT TIME ZONE 'UTC' AS commit_time,
+        ai.name AS ai_name,
+        ma.org AS ai_org,
+        ci.name AS ci_name,
+        mc.org AS ci_org,
+        count(*) AS commits_in_pr
+    FROM git.default.commits c
+        JOIN memory.default.gh_idents ai ON ai.email = c.author_email OR CONTAINS(ai.extra_emails, c.author_email)
+        JOIN memory.default.gh_idents ci ON ci.email = c.committer_email OR CONTAINS(ci.extra_emails, c.committer_email)
+        LEFT JOIN members ma ON CONTAINS(ai.logins, ma.login)
+        LEFT JOIN members mc ON CONTAINS(ci.logins, mc.login)
+    WHERE ai.email != ci.email
+    GROUP BY 1, 2, 3, 4, 5
+)
+SELECT
+    ai_name AS author_name,
+    ai_org AS author_org,
+    ci_name AS commiter_name,
+    ci_org AS commiter_org,
+    sum(commits_in_pr) AS commits,
+    count(*) AS pull_requests
+FROM pairs
+GROUP BY 1, 2, 3, 4
+ORDER BY pull_requests DESC
+LIMIT 50
+;


### PR DESCRIPTION
Detects most active author+commiter pairs based on git commits broken down per year

We suspect having a designated maintainer which merges PRs really speeds up things.